### PR TITLE
Pretty ounces

### DIFF
--- a/front/src/Quantity.elm
+++ b/front/src/Quantity.elm
@@ -24,41 +24,94 @@ type Units
     | Oz
 
 
+formatInteger : Float -> String
+formatInteger d =
+    if floor d == 0 then
+        ""
+    else
+      String.fromInt (floor d)
+
+
+-- Expects number between 0 and 100, floored.
+formatFractional : Float -> String
+formatFractional d =
+    if d == 0 then
+        ""
+    else if d == 10 then
+        "⅒"
+    else if d == 11 then
+        "⅑"
+    else if d == 12 then
+        "⅛"
+    else if d == 14 then
+        "⅐"
+    else if d == 16 then
+        "⅙"
+    else if d == 20 then
+        "⅕"
+    else if d == 25 then
+        "¼"
+    else if d == 33 then
+        "⅓"
+    else if d == 37 then
+        "⅜"
+    else if d == 40 then
+        "⅖"
+    else if d == 50 then
+        "½"
+    else if d == 60 then
+        "⅗"
+    else if d == 62 then
+        "⅝"
+    else if d == 66 then
+        "⅔"
+    else if d == 75 then
+        "¾"
+    else if d == 80 then
+        "⅘"
+    else if d == 83 then
+        "⅚"
+    else if d == 87 then
+        "⅞"
+    else
+        "." ++ String.fromFloat d
+
+
+formatFloat : Float -> String
+formatFloat d =
+    formatInteger d ++ formatFractional ( toFloat ( floor ( ( d - toFloat ( floor d ) ) * 100 ) ) )
+
+
+plural : String -> String -> Int -> String
+plural word suffix d =
+    if d == 1 then
+        word
+    else
+        word ++ suffix
+
+
 printQuantity : Units -> Quantity -> String
 printQuantity units quantity =
     case quantity of
         CL a ->
             case units of
                 Cl ->
-                    String.fromFloat a ++ " Cl"
+                    formatFloat a ++ " Cl"
 
                 Ml ->
-                    String.fromFloat (a * 10) ++ " Ml"
+                    formatFloat (a * 10) ++ " Ml"
 
                 Oz ->
-                    String.fromFloat (toFloat (floor (a * 0.3519503 * 100)) / 100) ++ " Oz"
+                    formatFloat (a * 1 / 3) ++ " Oz"
 
         Cube a ->
-            if a == 1 then
-                "1 cube"
-
-            else
-                String.fromInt a ++ " cube"
-
+            String.fromInt a ++ plural " cube" "s" a
 
         Dash a ->
-            if a == 1 then
-                "1 dash"
-
-            else
-                String.fromInt a ++ " dashes"
+            String.fromInt a ++ plural " dash" "es" a
 
         Drop a ->
-            if a == 1 then
-                "1 drop"
-
-            else
-                String.fromInt a ++ " drops"
+            String.fromInt a ++ plural " drop" "s" a
 
         FewDrops ->
             "Few drops"
@@ -67,38 +120,19 @@ printQuantity units quantity =
             "Few dashes"
 
         Slice a ->
-            if a == 0.5 then
-                "Half slice"
-
-            else if a == 1 then
-                "1 slice"
-
-            else
-                String.fromFloat a ++ " slices"
+            formatFloat a ++ plural " slice" "s" ( floor a )
 
         Splash a ->
-            if a == 1 then
-                "Splash"
-
-            else
-                String.fromInt a ++ " splashes"
+            String.fromInt a ++ plural " splash" "es" a
 
         Sprig a ->
-            if a == 1 then
-                "1 sprig"
-
-            else
-                String.fromInt a ++ " sprigs"
+            String.fromInt a ++ plural " sprig" "s" a
 
         Tsp a ->
-            String.fromFloat a ++ " Tsp"
+            formatFloat a ++ " Tsp"
 
         Wedge a ->
-            if a == 1 then
-                "1 wedge"
-
-            else
-                String.fromInt a ++ " wedges"
+            String.fromInt a ++ plural " wedge" "s" a
 
         Whole a ->
             String.fromInt a


### PR DESCRIPTION
*   Use 30ml as one ounce: (fractions of) 30 are the increment used by IBA,
    so this does away with weird numbers
*   Format floats as fractions: 0.5 -> ½
*   Add utility to handle plurals

This changes the current behavior:

<img width="610" alt="Screen Shot 2020-03-25 at 11 37 31 am" src="https://user-images.githubusercontent.com/944406/77527800-21848b00-6e8d-11ea-8f7a-b231df2841d7.png">

To:

<img width="612" alt="Screen Shot 2020-03-25 at 11 37 50 am" src="https://user-images.githubusercontent.com/944406/77527808-25b0a880-6e8d-11ea-8b4b-7d877cdda85b.png">

Note that fractions are also applied to other floats:

<img width="614" alt="Screen Shot 2020-03-25 at 11 39 07 am" src="https://user-images.githubusercontent.com/944406/77527883-4547d100-6e8d-11ea-86e1-8fb7785bf97e.png">

Unfortunately fractions are a bit hard to read. We could also opt to do `1/2`. Or make it optional. 

Finally: I’m bad at Elm. The code isn’t great.