### PR TITLE
Format non-liquid ingredients better

### DIFF
--- a/front/src/Main.elm
+++ b/front/src/Main.elm
@@ -893,9 +893,8 @@ displayRecipe model recipe =
                     paragraph []
                         [ text
                             ("◦ "
-                                ++ printQuantity model.units ingredient.quantity
+                                ++ printQuantity ingredient.material.name ingredient.quantity model.units
                                 ++ " "
-                                ++ ingredient.material.name
                                 ++ replacement model.pedantic ingredient
                                 ++ (if ingredient.optional then
                                         " (optional)"

--- a/front/src/Quantity.elm
+++ b/front/src/Quantity.elm
@@ -90,55 +90,55 @@ plural word suffix d =
         word ++ suffix
 
 
-printQuantity : Units -> Quantity -> String
-printQuantity units quantity =
+printQuantity : String -> Quantity -> Units -> String
+printQuantity name quantity units =
     case quantity of
         CL a ->
             case units of
                 Cl ->
-                    formatFloat a ++ " Cl"
+                    formatFloat a ++ " Cl " ++ name
 
                 Ml ->
-                    formatFloat (a * 10) ++ " Ml"
+                    formatFloat (a * 10) ++ " Ml " ++ name
 
                 Oz ->
-                    formatFloat (a * 1 / 3) ++ " Oz"
+                    formatFloat (a * 1 / 3) ++ " Oz " ++ name
 
         Cube a ->
-            String.fromInt a ++ plural " cube" "s" a
+            name ++ ": " ++ String.fromInt a ++ plural " cube" "s" a
 
         Dash a ->
-            String.fromInt a ++ plural " dash" "es" a
+            name ++ ": " ++ String.fromInt a ++ plural " dash" "es" a
 
         Drop a ->
-            String.fromInt a ++ plural " drop" "s" a
+            name ++ ": " ++ String.fromInt a ++ plural " drop" "s" a
 
         FewDrops ->
-            "Few drops"
+            name ++ ": Few drops"
 
         FewDashes ->
-            "Few dashes"
+            name ++ ": Few dashes"
 
         Slice a ->
-            formatFloat a ++ plural " slice" "s" ( floor a )
+            name ++ ": " ++ formatFloat a ++ plural " slice" "s" ( floor a )
 
         Splash a ->
-            String.fromInt a ++ plural " splash" "es" a
+            name ++ ": " ++ String.fromInt a ++ plural " splash" "es" a
 
         Sprig a ->
-            String.fromInt a ++ plural " sprig" "s" a
+            name ++ ": " ++ String.fromInt a ++ plural " sprig" "s" a
 
         Tsp a ->
-            formatFloat a ++ " Tsp"
+            formatFloat a ++ " Tsp " ++ name
 
         Wedge a ->
-            String.fromInt a ++ plural " wedge" "s" a
+            name ++ ": " ++ String.fromInt a ++ plural " wedge" "s" a
 
         Whole a ->
-            String.fromInt a
+            name ++ ": " ++ String.fromInt a
 
         Custom str ->
-            str
+            name ++ ": " ++ str
 
         None ->
-            ""
+            name


### PR DESCRIPTION
Non-liquid ingredients were displayed a bit weirdly (due to my changes over the days):

Current behavior:

<img width="616" alt="Screen Shot 2020-03-26 at 7 49 32 am" src="https://user-images.githubusercontent.com/944406/77618428-952ea280-6f36-11ea-9fc0-888d891f1cd7.png">

Proposed behavior:

<img width="624" alt="Screen Shot 2020-03-26 at 7 49 21 am" src="https://user-images.githubusercontent.com/944406/77618451-9f50a100-6f36-11ea-9d58-60e6b5ea4f65.png">

It could be even better probably, but this is at least more readable than the current!