### PR TITLE
Fix external links. Fixes #50

### DIFF
--- a/front/src/Main.elm
+++ b/front/src/Main.elm
@@ -379,8 +379,13 @@ update msg model =
         ChangedUrl _ ->
             ( model, Cmd.none )
 
-        ClickedLink _ ->
-            ( model, Cmd.none )
+        ClickedLink urlRequest ->
+            case urlRequest of
+                Browser.Internal _ ->
+                    ( model, Cmd.none )
+
+                Browser.External href ->
+                    ( model, Nav.load href )
 
 
 resizeHandler : Int -> Int -> Msg


### PR DESCRIPTION
Generally cribbed from the [Navigation example](https://guide.elm-lang.org/webapps/navigation.html) from Elm - for internal links, we do nothing because they 'just work', for external links we have to set the URL ourselves.